### PR TITLE
Remove dependencies of FindBugs and Guava

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,8 +23,6 @@ repositories {
 }
 
 dependencies {
-    api "com.google.code.findbugs:annotations:3.0.0"
-    api "com.google.guava:guava:18.0"
     testCompile "junit:junit:4.13"
 }
 


### PR DESCRIPTION
As Embulk (`embulk-core`) is going not to depend on FindBugs nor Guava, removing them.

Removing an annotation (was nice to have, but not mandatory), and replacing Guava's convenient methods with its own implementation.